### PR TITLE
Make widen_search/narrow_search adhere to GTP spec.

### DIFF
--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -273,6 +273,10 @@ float UCTNode::get_search_width() {
 	return m_search_width;
 }
 
+void UCTNode::reset_search_width() {
+    m_search_width = UCTSearch::DEFAULT_SEARCH_WIDTH;
+}
+
 void UCTNode::widen_search() {
 	m_search_width = (0.558 * m_search_width); // Smaller values cause the search to WIDEN
 	if (m_search_width < 0.003) {

--- a/src/UCTNode.h
+++ b/src/UCTNode.h
@@ -71,9 +71,10 @@ public:
     float get_lcb_binomial(int color) const;
 	float get_ucb_binomial(int color) const;
 
-	//static float m_search_width;
-	static float get_search_width(); // VARIABLE "m_search_width" IS INITIALIZED AS EXTERN IN GTP.CPP AND GTP.H
-	static void widen_search(); // Called from GTP.cpp as a gtp command
+    // VARIABLE "m_search_width" IS INITIALIZED AS EXTERN IN GTP.CPP AND GTP.H
+	static float get_search_width();
+    static void reset_search_width();
+	static void widen_search();  // Called from GTP.cpp as a gtp command
 	static void narrow_search(); // Called from GTP.cpp as a gtp command
 
     void virtual_loss();

--- a/src/UCTSearch.h
+++ b/src/UCTSearch.h
@@ -89,6 +89,12 @@ public:
     static constexpr size_t MIN_TREE_SPACE = 100'000'000;
 
     /*
+        Default search width.
+        Searches approximately a width of approx. 2-4 moves initially.
+    */
+    static constexpr float DEFAULT_SEARCH_WIDTH = 1.0f;
+
+    /*
         Value representing unlimited visits or playouts. Due to
         concurrent updates while multithreading, we need some
         headroom within the native type.


### PR DESCRIPTION
Also added the "reset" parameter to narrow_search to reset the
search width to a known range.

It works now like this:

```
~/lz/lz_ancalogonx/leela-zero/build# ./leelaz -g --cpu-only -w ../../../leela-zero/251b7ca85b3fae0e19e55e9f79abdc5ec3d6832ad2819131581127a0c0c6b4b0
Using 2 thread(s).
RNG seed: 14742205489067371793
BLAS Core: built-in Eigen 3.3.5 library.
Detecting residual layers...v1...64 channels...5 blocks.
Initializing CPU-only evaluation.
Setting max tree size to 4380 MiB and cache size to 486 MiB.
widen_search
= 558

widen_search
= 311

widen_search
= 173

widen_search
= 96

widen_search reset
= 1000

narrow_search
= 1000

widen_search
= 558

narrow_search
= 997

narrow_search
= 1000
```